### PR TITLE
Simple fix for code mirror light theme

### DIFF
--- a/scss/_codemirror.scss
+++ b/scss/_codemirror.scss
@@ -24,3 +24,27 @@ div.cm-s-solarized.CodeMirror {
     background-color: var(--ctp-tertiary-background-color);
   }
 }
+
+/* simple light theme fix */
+
+.cm-s-solarized.cm-s-light {
+  @include codemirror.theme;
+}
+
+.cm-s-solarized.cm-s-light {
+    text-shadow: unset;
+}
+
+.cm-s-solarized.cm-s-light .CodeMirror-linenumber {
+    text-shadow: unset;
+}
+
+.cm-s-solarized.cm-s-light.CodeMirror, .cm-s-solarized.cm-s-light .CodeMirror-gutters {
+  background-color: var(--ctp-secondary-background-color);
+}
+
+.embed.embed-page {
+  .cm-s-solarized.cm-s-light.CodeMirror, .cm-s-solarized.cm-s-light .CodeMirror-gutters {
+    background-color: var(--ctp-tertiary-background-color);
+  }
+}

--- a/scss/_codemirror.scss
+++ b/scss/_codemirror.scss
@@ -3,48 +3,27 @@
 div.cm-s-solarized.CodeMirror {
   @include codemirror.variables;
 }
-.cm-s-solarized.cm-s-dark {
-  @include codemirror.theme;
+
+.cm-s-solarized {
+    &.cm-s-light, &.cm-s-dark {
+        @include codemirror.theme;
+        text-shadow: unset;
+        box-shadow: inset 7px 0 12px -6px var(--ctp-secondary-background-color);
+
+        &.CodeMirror, .CodeMirror-gutters {
+          background-color: var(--ctp-secondary-background-color);
+        }
+
+        .CodeMirror-linenumber {
+          text-shadow: unset;
+        }
+    }
 }
 
-.cm-s-solarized.cm-s-dark {
-    text-shadow: unset;
-}
-
-.cm-s-solarized.cm-s-dark .CodeMirror-linenumber {
-    text-shadow: unset;
-}
-
-.cm-s-solarized.cm-s-dark.CodeMirror, .cm-s-solarized.cm-s-dark .CodeMirror-gutters {
-  background-color: var(--ctp-secondary-background-color);
-}
-
-.embed.embed-page {
-  .cm-s-solarized.cm-s-dark.CodeMirror, .cm-s-solarized.cm-s-dark .CodeMirror-gutters {
-    background-color: var(--ctp-tertiary-background-color);
-  }
-}
-
-/* simple light theme fix */
-
-.cm-s-solarized.cm-s-light {
-  @include codemirror.theme;
-}
-
-.cm-s-solarized.cm-s-light {
-    text-shadow: unset;
-}
-
-.cm-s-solarized.cm-s-light .CodeMirror-linenumber {
-    text-shadow: unset;
-}
-
-.cm-s-solarized.cm-s-light.CodeMirror, .cm-s-solarized.cm-s-light .CodeMirror-gutters {
-  background-color: var(--ctp-secondary-background-color);
-}
-
-.embed.embed-page {
-  .cm-s-solarized.cm-s-light.CodeMirror, .cm-s-solarized.cm-s-light .CodeMirror-gutters {
-    background-color: var(--ctp-tertiary-background-color);
+.embed.embed-page .cm-s-solarized {
+  &.cm-s-dark, &.cm-s-light {
+    &.CodeMirror, .CodeMirror-gutters{
+      background-color: var(--ctp-tertiary-background-color);
+    }
   }
 }


### PR DESCRIPTION
Regarding Issue https://github.com/catppuccin/logseq/issues/13

Just copying the dark theme configuration in `_codemirror.scss` for the light theme (catppuccin latte).
You can probably simplify the sass to remove the repetition... but it works this way!

Here is the result:

Before (default solarized look while catppuccin latte is selected as logseq theme):
![logseq-ctp-code-block](https://github.com/catppuccin/logseq/assets/13813609/01b82f01-7963-405a-83f9-7e81daa8e242)


After:
![image](https://github.com/catppuccin/logseq/assets/13813609/1be0a08b-7f9a-4077-aac7-b8fa7c118e07)
