### PR TITLE
feat: fix highlighted text foreground color.

### DIFF
--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -167,7 +167,7 @@ html[data-theme=dark] .cp__right-sidebar-topbar button {
 
 // selection
 ::selection {
-    color: var(--ctp-color-level-1);
+    color: var(--ls-text-on-accent);
 }
 
 .inline.with-bg-color {

--- a/scss/_ls-vars.scss
+++ b/scss/_ls-vars.scss
@@ -3,6 +3,7 @@
   --ls-error-color: var(--ctp-error-color);
   --ls-warning-color: var(--ctp-warning-color);
   --ls-success-color: var(--ctp-success-color);
+  --ls-text-on-accent: rgb(var(--ctp-base));
   .logseq-tldraw {
     --tl-selectFill: rgba(var(--ctp-tl-selectFill), 0.05);
     --tl-selectStroke: rgb(var(--ctp-tl-selectStroke));


### PR DESCRIPTION
Issue
---
When using the theme the foreground color of the selected text is too similar to the background color set by logseq on selection. This is bad from an accessabilty standpoint and makes using logseq with this theme harder due to missing contrast.

Background
---
logseq-catppuccin sets the foreground color only while leaving it to the logseq default theme to handle the background color.

Solution
---
I looked at how the obsidian catppuccin theme handled the color of the selection. They introduced an new var `--text-on-accent` that handles the foreground color. It is basically just a new name for the value in `--ctp-base`. I added a new var `--ls-text-on-accent` recreating this behavior and use this as the value for the selection's foreground color.