### PR TITLE
fix: use --ctp-text, not --ctp-text

### DIFF
--- a/scss/_ls-vars.scss
+++ b/scss/_ls-vars.scss
@@ -3,7 +3,7 @@
   --ls-error-color: var(--ctp-error-color);
   --ls-warning-color: var(--ctp-warning-color);
   --ls-success-color: var(--ctp-success-color);
-  --ls-text-on-accent: rgb(var(--ctp-base));
+  --ls-text-on-accent: rgb(var(--ctp-text));
   .logseq-tldraw {
     --tl-selectFill: rgba(var(--ctp-tl-selectFill), 0.05);
     --tl-selectStroke: rgb(var(--ctp-tl-selectStroke));


### PR DESCRIPTION
Sorry, about this mishap on my regards. I confused `--ctp-base` and `--ctp-text` and patched the exact same faulty behavior into the initial PR. 🤦‍♂️